### PR TITLE
feat : endpoints to tag and retrieve tags for files stored in AWS S3

### DIFF
--- a/aws-s3-project/src/main/java/com/learning/awspring/controller/FileInfoController.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/controller/FileInfoController.java
@@ -1,9 +1,9 @@
 package com.learning.awspring.controller;
 
 import com.learning.awspring.entities.FileInfo;
-import com.learning.awspring.model.GenericResponse;
-import com.learning.awspring.model.SignedURLResponse;
-import com.learning.awspring.model.SignedUploadRequest;
+import com.learning.awspring.model.request.SignedUploadRequest;
+import com.learning.awspring.model.response.GenericResponse;
+import com.learning.awspring.model.response.SignedURLResponse;
 import com.learning.awspring.service.AwsS3Service;
 import com.learning.awspring.service.FileInfoService;
 import io.awspring.cloud.s3.S3Resource;

--- a/aws-s3-project/src/main/java/com/learning/awspring/controller/S3TaggingController.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/controller/S3TaggingController.java
@@ -3,6 +3,8 @@ package com.learning.awspring.controller;
 import com.learning.awspring.model.request.ObjectTaggingRequest;
 import com.learning.awspring.model.response.ObjectTaggingResponse;
 import com.learning.awspring.service.AwsS3Service;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,7 +31,7 @@ public class S3TaggingController {
      */
     @PostMapping
     public ResponseEntity<ObjectTaggingResponse> tagObject(
-            @RequestBody ObjectTaggingRequest taggingRequest) {
+            @RequestBody @Valid ObjectTaggingRequest taggingRequest) {
         ObjectTaggingResponse response = awsS3Service.tagObject(taggingRequest);
         return ResponseEntity.ok(response);
     }
@@ -41,7 +43,8 @@ public class S3TaggingController {
      * @return Response with the object's tags
      */
     @GetMapping("/{fileName}")
-    public ResponseEntity<ObjectTaggingResponse> getObjectTags(@PathVariable String fileName) {
+    public ResponseEntity<ObjectTaggingResponse> getObjectTags(
+            @PathVariable @Valid @NotBlank String fileName) {
         ObjectTaggingResponse response = awsS3Service.getObjectTags(fileName);
         return ResponseEntity.ok(response);
     }

--- a/aws-s3-project/src/main/java/com/learning/awspring/controller/S3TaggingController.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/controller/S3TaggingController.java
@@ -1,0 +1,48 @@
+package com.learning.awspring.controller;
+
+import com.learning.awspring.model.request.ObjectTaggingRequest;
+import com.learning.awspring.model.response.ObjectTaggingResponse;
+import com.learning.awspring.service.AwsS3Service;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/s3/tags")
+public class S3TaggingController {
+
+    private final AwsS3Service awsS3Service;
+
+    public S3TaggingController(AwsS3Service awsS3Service) {
+        this.awsS3Service = awsS3Service;
+    }
+
+    /**
+     * Add or update tags for an object in S3.
+     *
+     * @param taggingRequest The request containing the object key and tags
+     * @return Response with the result of the tagging operation
+     */
+    @PostMapping
+    public ResponseEntity<ObjectTaggingResponse> tagObject(
+            @RequestBody ObjectTaggingRequest taggingRequest) {
+        ObjectTaggingResponse response = awsS3Service.tagObject(taggingRequest);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Get all tags for an object in S3.
+     *
+     * @param fileName The name of the file/object
+     * @return Response with the object's tags
+     */
+    @GetMapping("/{fileName}")
+    public ResponseEntity<ObjectTaggingResponse> getObjectTags(@PathVariable String fileName) {
+        ObjectTaggingResponse response = awsS3Service.getObjectTags(fileName);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/aws-s3-project/src/main/java/com/learning/awspring/model/request/ObjectTaggingRequest.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/model/request/ObjectTaggingRequest.java
@@ -1,0 +1,9 @@
+package com.learning.awspring.model.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.io.Serializable;
+import java.util.Map;
+
+public record ObjectTaggingRequest(@NotBlank String fileName, @NotEmpty Map<String, String> tags)
+        implements Serializable {}

--- a/aws-s3-project/src/main/java/com/learning/awspring/model/request/SignedUploadRequest.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/model/request/SignedUploadRequest.java
@@ -1,4 +1,4 @@
-package com.learning.awspring.model;
+package com.learning.awspring.model.request;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/aws-s3-project/src/main/java/com/learning/awspring/model/response/GenericResponse.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/model/response/GenericResponse.java
@@ -1,3 +1,3 @@
-package com.learning.awspring.model;
+package com.learning.awspring.model.response;
 
 public record GenericResponse(String message) {}

--- a/aws-s3-project/src/main/java/com/learning/awspring/model/response/ObjectTaggingResponse.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/model/response/ObjectTaggingResponse.java
@@ -1,0 +1,7 @@
+package com.learning.awspring.model.response;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public record ObjectTaggingResponse(String fileName, Map<String, String> tags, boolean success)
+        implements Serializable {}

--- a/aws-s3-project/src/main/java/com/learning/awspring/model/response/SignedURLResponse.java
+++ b/aws-s3-project/src/main/java/com/learning/awspring/model/response/SignedURLResponse.java
@@ -1,4 +1,4 @@
-package com.learning.awspring.model;
+package com.learning.awspring.model.response;
 
 import java.net.URL;
 

--- a/aws-s3-project/src/test/java/com/learning/awspring/controller/FileInfoControllerIT.java
+++ b/aws-s3-project/src/test/java/com/learning/awspring/controller/FileInfoControllerIT.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.learning.awspring.common.AbstractIntegrationTest;
-import com.learning.awspring.model.SignedUploadRequest;
+import com.learning.awspring.model.request.SignedUploadRequest;
 import io.awspring.cloud.s3.S3Template;
 import java.util.Map;
 import org.junit.jupiter.api.MethodOrderer;

--- a/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerIT.java
+++ b/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerIT.java
@@ -52,5 +52,27 @@ public class S3TaggingControllerIT extends AbstractIntegrationTest {
                 .andExpect(jsonPath("$.tags.confidential").value("yes"))
                 .andExpect(jsonPath("$.tags.department").value("finance"))
                 .andExpect(jsonPath("$.success").value(true));
+
+        // Then test retrieving the tags
+        mockMvc.perform(get("/s3/tags/" + fileName))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.fileName").value(fileName))
+                .andExpect(jsonPath("$.tags.category").value("document"))
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    void getObjectTags_WithNonexistentFile_ShouldReturnFailureResponse() throws Exception {
+        // Arrange
+        String fileName = "nonexistent-file.pdf";
+
+        // Act & Assert
+        mockMvc.perform(get("/s3/tags/{fileName}", fileName))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.fileName").value(fileName))
+                .andExpect(jsonPath("$.tags").isEmpty())
+                .andExpect(jsonPath("$.success").value(false));
     }
 }

--- a/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerIT.java
+++ b/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerIT.java
@@ -1,0 +1,56 @@
+package com.learning.awspring.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.learning.awspring.common.AbstractIntegrationTest;
+import com.learning.awspring.model.request.ObjectTaggingRequest;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class S3TaggingControllerIT extends AbstractIntegrationTest {
+
+    @Test
+    void tagObject_WithValidRequest_ShouldReturnSuccessResponse() throws Exception {
+        // Arrange
+        String fileName = "test-document.txt";
+
+        MockMultipartFile file =
+                new MockMultipartFile(
+                        "file", fileName, MediaType.TEXT_PLAIN_VALUE, "Hello, World!".getBytes());
+
+        // Perform the request and assert the response
+        mockMvc.perform(multipart("/s3/upload").file(file))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fileName").value("test-document.txt"))
+                .andExpect(
+                        jsonPath("$.fileUrl")
+                                .value(containsString("/testbucket/test-document.txt")));
+
+        Map<String, String> tags = new HashMap<>();
+        tags.put("category", "document");
+        tags.put("confidential", "yes");
+        tags.put("department", "finance");
+
+        ObjectTaggingRequest request = new ObjectTaggingRequest(fileName, tags);
+
+        // Act & Assert
+        mockMvc.perform(
+                        post("/s3/tags")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.fileName").value(fileName))
+                .andExpect(jsonPath("$.tags.category").value("document"))
+                .andExpect(jsonPath("$.tags.confidential").value("yes"))
+                .andExpect(jsonPath("$.tags.department").value("finance"))
+                .andExpect(jsonPath("$.success").value(true));
+    }
+}

--- a/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerTest.java
+++ b/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerTest.java
@@ -43,9 +43,6 @@ class S3TaggingControllerTest {
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mockResponse, response.getBody());
-        assertEquals(true, response.getBody().success());
-        assertEquals("test-file.pdf", response.getBody().fileName());
-        assertEquals(tags, response.getBody().tags());
     }
 
     @Test
@@ -67,8 +64,5 @@ class S3TaggingControllerTest {
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mockResponse, response.getBody());
-        assertEquals(true, response.getBody().success());
-        assertEquals(fileName, response.getBody().fileName());
-        assertEquals(tags, response.getBody().tags());
     }
 }

--- a/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerTest.java
+++ b/aws-s3-project/src/test/java/com/learning/awspring/controller/S3TaggingControllerTest.java
@@ -1,0 +1,74 @@
+package com.learning.awspring.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import com.learning.awspring.model.request.ObjectTaggingRequest;
+import com.learning.awspring.model.response.ObjectTaggingResponse;
+import com.learning.awspring.service.AwsS3Service;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class S3TaggingControllerTest {
+
+    @Mock private AwsS3Service awsS3Service;
+
+    @InjectMocks private S3TaggingController controller;
+
+    @Test
+    void tagObject_shouldReturnSuccessResponse() {
+        // Arrange
+        Map<String, String> tags = new HashMap<>();
+        tags.put("category", "document");
+        tags.put("confidential", "yes");
+
+        ObjectTaggingRequest request = new ObjectTaggingRequest("test-file.pdf", tags);
+        ObjectTaggingResponse mockResponse = new ObjectTaggingResponse("test-file.pdf", tags, true);
+
+        when(awsS3Service.tagObject(request)).thenReturn(mockResponse);
+
+        // Act
+        ResponseEntity<ObjectTaggingResponse> response = controller.tagObject(request);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockResponse, response.getBody());
+        assertEquals(true, response.getBody().success());
+        assertEquals("test-file.pdf", response.getBody().fileName());
+        assertEquals(tags, response.getBody().tags());
+    }
+
+    @Test
+    void getObjectTags_shouldReturnTags() {
+        // Arrange
+        String fileName = "test-file.pdf";
+        Map<String, String> tags = new HashMap<>();
+        tags.put("category", "document");
+        tags.put("confidential", "yes");
+
+        ObjectTaggingResponse mockResponse = new ObjectTaggingResponse(fileName, tags, true);
+
+        when(awsS3Service.getObjectTags(fileName)).thenReturn(mockResponse);
+
+        // Act
+        ResponseEntity<ObjectTaggingResponse> response = controller.getObjectTags(fileName);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(mockResponse, response.getBody());
+        assertEquals(true, response.getBody().success());
+        assertEquals(fileName, response.getBody().fileName());
+        assertEquals(tags, response.getBody().tags());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added endpoints to tag and retrieve tags for files stored in AWS S3.
  - Users can now assign or update custom tags to S3 objects and fetch existing tags via the application interface.

- **Bug Fixes**
  - None.

- **Tests**
  - Introduced integration and unit tests to verify the new S3 tagging functionality and ensure correct behavior.

- **Chores**
  - Updated internal organization of some response and request types for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->