### PR TITLE
chore(deps): update localstack/localstack docker tag to v4.5.0

### DIFF
--- a/aws-cloudwatch-project/src/test/java/com/example/awsspring/common/ContainerConfig.java
+++ b/aws-cloudwatch-project/src/test/java/com/example/awsspring/common/ContainerConfig.java
@@ -14,7 +14,7 @@ public class ContainerConfig {
     @ServiceConnection
     LocalStackContainer localstackContainer() {
         return new LocalStackContainer(
-                DockerImageName.parse("localstack/localstack").withTag("4.2.0"));
+                DockerImageName.parse("localstack/localstack").withTag("4.5.0"));
     }
 
     @Bean

--- a/aws-dynamodb-project/src/test/java/com/learning/awsspring/common/ContainerConfig.java
+++ b/aws-dynamodb-project/src/test/java/com/learning/awsspring/common/ContainerConfig.java
@@ -21,7 +21,7 @@ public class ContainerConfig {
     LocalStackContainer localstackContainer() {
         LocalStackContainer localstackContainer =
                 new LocalStackContainer(
-                                DockerImageName.parse("localstack/localstack").withTag("4.2.0"))
+                                DockerImageName.parse("localstack/localstack").withTag("4.5.0"))
                         .withCopyFileToContainer(
                                 MountableFile.forHostPath(".localstack/"),
                                 "/etc/localstack/init/ready.d/")

--- a/aws-kinesis-project/consumer/src/test/java/com/learning/aws/spring/common/ContainersConfig.java
+++ b/aws-kinesis-project/consumer/src/test/java/com/learning/aws/spring/common/ContainersConfig.java
@@ -14,7 +14,7 @@ public class ContainersConfig {
     @Bean
     LocalStackContainer localStackContainer() {
         return new LocalStackContainer(
-                DockerImageName.parse("localstack/localstack").withTag("4.2.0"));
+                DockerImageName.parse("localstack/localstack").withTag("4.5.0"));
     }
 
     @Bean

--- a/aws-kinesis-project/producer/src/test/java/com/learning/aws/spring/common/ContainerConfig.java
+++ b/aws-kinesis-project/producer/src/test/java/com/learning/aws/spring/common/ContainerConfig.java
@@ -25,7 +25,7 @@ public class ContainerConfig {
     @Bean
     LocalStackContainer localStackContainer() {
         return new LocalStackContainer(
-                DockerImageName.parse("localstack/localstack").withTag("4.2.0"));
+                DockerImageName.parse("localstack/localstack").withTag("4.5.0"));
     }
 
     @Bean

--- a/aws-lambda-project/src/test/java/com/learning/awslambda/ApplicationIntegrationTest.java
+++ b/aws-lambda-project/src/test/java/com/learning/awslambda/ApplicationIntegrationTest.java
@@ -64,7 +64,7 @@ class ApplicationIntegrationTest {
 
     @Container
     static LocalStackContainer localstack = new LocalStackContainer(
-                    DockerImageName.parse("localstack/localstack").withTag("4.2.0"))
+                    DockerImageName.parse("localstack/localstack").withTag("4.5.0"))
             .withNetwork(network)
             .withEnv("LOCALSTACK_HOST", "localhost.localstack.cloud")
             .withEnv("LAMBDA_DOCKER_NETWORK", ((Network.NetworkImpl) network).getName())

--- a/aws-parameterstore-project/src/test/java/com/example/awsspring/common/LocalStackContainerConfig.java
+++ b/aws-parameterstore-project/src/test/java/com/example/awsspring/common/LocalStackContainerConfig.java
@@ -14,7 +14,7 @@ public class LocalStackContainerConfig {
 
     @Container
     private static final LocalStackContainer localStackContainer =
-            new LocalStackContainer(DockerImageName.parse("localstack/localstack").withTag("4.2.0"))
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack").withTag("4.5.0"))
                     .withCopyFileToContainer(
                             MountableFile.forHostPath("localstack/"),
                             "/etc/localstack/init/ready.d/")

--- a/aws-secretmanager-project/src/test/java/com/example/awsspring/TestApplication.java
+++ b/aws-secretmanager-project/src/test/java/com/example/awsspring/TestApplication.java
@@ -19,7 +19,7 @@ public class TestApplication {
     @ServiceConnection
     LocalStackContainer localStackContainer() {
         return new LocalStackContainer(
-                        DockerImageName.parse("localstack/localstack").withTag("4.2.0"))
+                        DockerImageName.parse("localstack/localstack").withTag("4.5.0"))
                 .withCopyFileToContainer(
                         MountableFile.forHostPath("localstack/"), "/etc/localstack/init/ready.d/")
                 .waitingFor(Wait.forLogMessage(".*LocalStack initialized successfully\n", 1));

--- a/aws-secretmanager-project/src/test/java/com/example/awsspring/common/LocalStackContainerConfig.java
+++ b/aws-secretmanager-project/src/test/java/com/example/awsspring/common/LocalStackContainerConfig.java
@@ -14,7 +14,7 @@ public class LocalStackContainerConfig {
 
     @Container
     private static final LocalStackContainer localStackContainer =
-            new LocalStackContainer(DockerImageName.parse("localstack/localstack").withTag("4.2.0"))
+            new LocalStackContainer(DockerImageName.parse("localstack/localstack").withTag("4.5.0"))
                     .withCopyFileToContainer(
                             MountableFile.forHostPath("localstack/"),
                             "/etc/localstack/init/ready.d/")

--- a/aws-ses-project/src/test/java/com/example/awsspring/common/LocalStackTestContainer.java
+++ b/aws-ses-project/src/test/java/com/example/awsspring/common/LocalStackTestContainer.java
@@ -17,7 +17,7 @@ public class LocalStackTestContainer {
     LocalStackContainer localStackContainer() {
         LocalStackContainer localStackContainer =
                 new LocalStackContainer(
-                        DockerImageName.parse("localstack/localstack").withTag("4.2.0"));
+                        DockerImageName.parse("localstack/localstack").withTag("4.5.0"));
         localStackContainer.start();
         Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
         localStackContainer.followOutput(logConsumer);

--- a/aws-sqs-project/src/test/java/com/learning/awspring/config/LocalStackTestContainers.java
+++ b/aws-sqs-project/src/test/java/com/learning/awspring/config/LocalStackTestContainers.java
@@ -13,7 +13,7 @@ public class LocalStackTestContainers {
     @ServiceConnection
     LocalStackContainer localstackContainer() {
         return new LocalStackContainer(
-                        DockerImageName.parse("localstack/localstack").withTag("4.2.0"))
+                        DockerImageName.parse("localstack/localstack").withTag("4.5.0"))
                 .withReuse(true);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the LocalStack Docker image version used in test configurations from 4.2.0 to 4.5.0 across multiple projects. No changes to test logic or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->